### PR TITLE
tests/repoconf: Use g_assert_cmpint over libcheck's new symbol

### DIFF
--- a/tests/test_repoconf.c
+++ b/tests/test_repoconf.c
@@ -86,7 +86,7 @@ repoconf_assert_uint64_eq(LrYumRepoConf *repoconf,
     gboolean ret = lr_yum_repoconf_getinfo(repoconf, &tmp_err, option, &val);
     ck_assert_msg(ret, "Getinfo failed for %d: %s", option, tmp_err->message);
     fail_if(tmp_err);
-    ck_assert_uint_eq(val, expected);
+    g_assert_cmpint(val, ==, expected);
 }
 
 #define conf_assert_uint64_eq(option, expected) \


### PR DESCRIPTION
RHEL7 has check-0.9.9-5.el7 which doesn't have the
ck_assert_uint_eq() symbol.  Since we're linking to GLib, and
it has a (IMO superior) API here, and it's been available
since approximately forever, let's use it.