### PR TITLE
tests: Pass true(1)/false(0) to ck_assert_msg, fix check.h backcompat

### DIFF
--- a/tests/fixtures.c
+++ b/tests/fixtures.c
@@ -41,12 +41,12 @@ void
 lr_assert_strv_eq(const gchar * const *strv, ...)
 {
     va_list args;
-    ck_assert_msg(strv, "NULL isn't strv");
+    ck_assert_msg(strv != NULL, "NULL isn't strv");
     va_start (args, strv);
     gchar **strv_p = (gchar **) strv;
     for (; *strv_p; strv_p++) {
         gchar *s = va_arg (args, gchar*);
-        ck_assert_msg(s, "Lengths of lists are not the same");
+        ck_assert_msg(s != NULL, "Lengths of lists are not the same");
         ck_assert_str_eq(*strv_p, s);
     }
 
@@ -54,11 +54,4 @@ lr_assert_strv_eq(const gchar * const *strv, ...)
                   "Lengths of lists are not the same");
 
     va_end (args);
-}
-
-void
-lr_assert_msg(int exp)
-{
-    if (!exp)
-        ck_abort();
 }

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -19,10 +19,11 @@ test_log_handler_cb(const gchar *log_domain, GLogLevelFlags log_level,
 void
 lr_assert_strv_eq(const gchar * const *strv, ...);
 
-
-#if (CHECK_MAJOR_VERSION == 0) && (CHECK_MINOR_VERSION == 9) && (CHECK_MICRO_VERSION <= 9)
-#define ck_assert_msg(exp, ...) lr_assert_msg((int) (exp))
-void lr_assert_msg(int exp);
+/* Old versions of check.h don't have this, just use g_assert() and drop
+   the message
+*/
+#ifndef ck_assert_msg
+#define ck_assert_msg(exp, ...) g_assert (exp)
 #endif
 
 #endif /* FIXTURES_H */

--- a/tests/test_repoconf.c
+++ b/tests/test_repoconf.c
@@ -24,7 +24,7 @@ repoconf_assert_true(LrYumRepoConf *repoconf,
     gboolean ret = lr_yum_repoconf_getinfo(repoconf, &tmp_err, option, &ptr);
     ck_assert_msg(ret, "Getinfo failed for %d: %s", option, tmp_err->message);
     fail_if(tmp_err);
-    ck_assert_msg(ptr, "Not a True value (Option %d)", option);
+    ck_assert_msg(ptr != NULL, "Not a True value (Option %d)", option);
 }
 
 #define conf_assert_true(option) \
@@ -154,13 +154,13 @@ repoconf_assert_strv_eq(LrYumRepoConf *repoconf,
     ck_assert_msg(ret, "Getinfo failed for %d: %s", option, tmp_err->message);
     fail_if(tmp_err);
 
-    ck_assert_msg(strv, "NULL isn't strv");
+    ck_assert_msg(strv != NULL, "NULL isn't strv");
 
     va_start (args, option);
     gchar **strv_p = strv;
     for (; *strv_p; strv_p++) {
         gchar *s = va_arg (args, gchar*);
-        ck_assert_msg(s, "Lengths of lists are not the same");
+        ck_assert_msg(s != NULL, "Lengths of lists are not the same");
         ck_assert_str_eq(*strv_p, s);
     }
 
@@ -513,7 +513,7 @@ START_TEST(test_write_repoconf)
     // Check if the repoconf with the section was created
     repos = lr_yum_repoconfs_get_list(confs, &tmp_err);
     ck_assert_msg(!tmp_err, tmp_err->message);
-    ck_assert_msg(repos, "No repo has been created");
+    ck_assert_msg(repos != NULL, "No repo has been created");
     conf = g_slist_nth_data(repos, 0);
 
     // Ty to set and get options


### PR DESCRIPTION
First; RHEL7.0 does have check-0.9.9 does have ck_assert_msg, so the
previous code was redefining it.

Second, we are passing pointer-sized values as the expression, when an
integer-sized value (really true/false) is expected.  Fix that with
explicit comparisons to NULL.